### PR TITLE
Pin watson-developer-cloud SDK to prevent breakage.

### DIFF
--- a/notebooks/watson_correlate_documents.ipynb
+++ b/notebooks/watson_correlate_documents.ipynb
@@ -65,7 +65,7 @@
     }
    ],
    "source": [
-    "!pip install --upgrade watson-developer-cloud"
+    "!pip install watson-developer-cloud==1.5"
    ]
   },
   {


### PR DESCRIPTION
The 2.0 version of Watson python SDK contains breaking changes.
Pin the version for now, and provide fixes in a later patch.